### PR TITLE
Reduce hero header font size

### DIFF
--- a/components/hero/index.tsx
+++ b/components/hero/index.tsx
@@ -46,9 +46,9 @@ export const Hero = () => {
                     <br />
                   </Text>
                   <Text h1 css={{display: 'inline', fontSize: '2.5rem'}} color="primary">
-                    +90% к эффективности операций,
+                    + 90% к эффективности
                     <br />
-                    -30% затрат
+                    - 30% затрат
                   </Text>
               </Box>
 

--- a/components/hero/index.tsx
+++ b/components/hero/index.tsx
@@ -41,14 +41,14 @@ export const Hero = () => {
                      maxWidth: '600px',
                   }}
                >
-                  <Text h1 css={{display: 'inline'}}>
-                     Автоматизация бизнеса с искусственным интеллектом:
-                     <br />
+                  <Text h1 css={{display: 'inline', fontSize: '2.5rem'}}>
+                    Автоматизация бизнеса с искусственным интеллектом:
+                    <br />
                   </Text>
-                  <Text h1 css={{display: 'inline'}} color="primary">
-                     +90% к эффективности операций,
-                     <br />
-                     -30% затрат
+                  <Text h1 css={{display: 'inline', fontSize: '2.5rem'}} color="primary">
+                    +90% к эффективности операций,
+                    <br />
+                    -30% затрат
                   </Text>
               </Box>
 


### PR DESCRIPTION
## Summary
- decrease font size of the hero header text to make it less overwhelming

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697163714c832d9d592f283c33e565